### PR TITLE
Fix focus-dependency: MCP tools work when notebook tab loses focus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,9 +73,13 @@ const cell = notebook.getCells().find(c => c.metadata.id === cellId);
 
 This distinction matters: cell IDs are an implementation detail for reliable async tracking, not part of the agent API.
 
-### Multi-Window Safety
+### Focus-Independent Operation
 
-Check `vscode.window.state.focused` before modifications - prevents executing in unfocused background windows.
+All MCP tools work regardless of which tab is focused. When no `notebook_uri` is provided:
+1. Uses `activeNotebookEditor` if available
+2. Falls back to single open notebook (unambiguous)
+3. Falls back to single visible notebook editor
+4. Returns error listing open notebooks with URIs if ambiguous
 
 ## Tool Design
 

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -23,7 +23,8 @@ export class WorkspaceEdit {
 }
 
 export const workspace = {
-  applyEdit: async () => true
+  applyEdit: async () => true,
+  notebookDocuments: [] as any[]
 };
 
 export const NotebookCellKind = {
@@ -34,6 +35,7 @@ export const NotebookCellKind = {
 // Window state for multi-window tests
 export const window = {
   activeNotebookEditor: undefined as any,
+  visibleNotebookEditors: [] as any[],
   state: { focused: true }
 };
 

--- a/src/mcp/tools/cells.ts
+++ b/src/mcp/tools/cells.ts
@@ -156,19 +156,20 @@ export function registerCellTools(server: McpServer) {
   // notebook_list_cells
   server.tool(
     "notebook_list_cells",
-    "List all cells in the active notebook with metadata including type, language, content preview, and execution state.",
-    ListCellsInputSchema.shape,
+    "List all cells in a notebook with metadata including type, language, content preview, and execution state.",
+    { ...ListCellsInputSchema.shape, notebook_uri: NotebookUriSchema },
     async (params) => {
-      const editor = vscode.window.activeNotebookEditor;
-
-      if (!editor) {
+      const parsed = z.object({ ...ListCellsInputSchema.shape, notebook_uri: NotebookUriSchema }).parse(params);
+      const accessCheck = await checkCanReadNotebook(parsed.notebook_uri);
+      if (!accessCheck.allowed) {
         return {
-          content: [{ type: "text" as const, text: "Error: No active notebook. Open a .ipynb file first." }],
+          content: [{ type: "text" as const, text: `Error: ${accessCheck.error}` }],
           isError: true
         };
       }
 
-      const cells = editor.notebook.getCells().map((cell, index) => ({
+      const notebook = accessCheck.notebook!;
+      const cells = notebook.getCells().map((cell, index) => ({
         index,
         kind: cell.kind === vscode.NotebookCellKind.Code ? "code" : "markdown",
         language: cell.document.languageId,
@@ -179,7 +180,7 @@ export function registerCellTools(server: McpServer) {
       }));
 
       const output = { total: cells.length, cells };
-      const { response_format } = ListCellsInputSchema.parse(params);
+      const { response_format } = parsed;
 
       if (response_format === ResponseFormat.JSON) {
         return {
@@ -214,17 +215,16 @@ Args:
   - response_format ('markdown' | 'json'): Output format (default: 'markdown')`,
     GetCellContentInputSchema.shape,
     async (params) => {
-      const editor = vscode.window.activeNotebookEditor;
-
-      if (!editor) {
+      const parsed = GetCellContentInputSchema.parse(params);
+      const accessCheck = await checkCanReadNotebook(parsed.notebook_uri);
+      if (!accessCheck.allowed) {
         return {
-          content: [{ type: "text" as const, text: "Error: No active notebook. Open a .ipynb file first." }],
+          content: [{ type: "text" as const, text: `Error: ${accessCheck.error}` }],
           isError: true
         };
       }
 
-      const parsed = GetCellContentInputSchema.parse(params);
-      const notebook = editor.notebook;
+      const notebook = accessCheck.notebook!;
 
       if (parsed.index >= notebook.cellCount) {
         return {
@@ -271,17 +271,16 @@ Args:
   - response_format ('markdown' | 'json'): Output format (default: 'markdown')`,
     GetCellOutputInputSchema.shape,
     async (params) => {
-      const editor = vscode.window.activeNotebookEditor;
-
-      if (!editor) {
+      const parsed = GetCellOutputInputSchema.parse(params);
+      const accessCheck = await checkCanReadNotebook(parsed.notebook_uri);
+      if (!accessCheck.allowed) {
         return {
-          content: [{ type: "text" as const, text: "Error: No active notebook. Open a .ipynb file first." }],
+          content: [{ type: "text" as const, text: `Error: ${accessCheck.error}` }],
           isError: true
         };
       }
 
-      const parsed = GetCellOutputInputSchema.parse(params);
-      const notebook = editor.notebook;
+      const notebook = accessCheck.notebook!;
 
       if (parsed.index >= notebook.cellCount) {
         return {
@@ -555,12 +554,14 @@ Args:
 Useful for navigating large notebooks without reading all cell contents.`,
     GetOutlineInputSchema.shape,
     async (params) => {
-      const editor = vscode.window.activeNotebookEditor;
-      if (!editor) {
-        return { content: [{ type: "text" as const, text: "Error: No active notebook." }], isError: true };
+      const parsed = GetOutlineInputSchema.parse(params);
+      const accessCheck = await checkCanReadNotebook(parsed.notebook_uri);
+      if (!accessCheck.allowed) {
+        return { content: [{ type: "text" as const, text: `Error: ${accessCheck.error}` }], isError: true };
       }
 
-      const { response_format } = GetOutlineInputSchema.parse(params);
+      const notebook = accessCheck.notebook!;
+      const { response_format } = parsed;
       const outline: Array<{
         cellIndex: number;
         cellType: string;
@@ -568,7 +569,7 @@ Useful for navigating large notebooks without reading all cell contents.`,
         items: Array<{ type: string; level?: number; name: string; line: number }>;
       }> = [];
 
-      for (const cell of editor.notebook.getCells()) {
+      for (const cell of notebook.getCells()) {
         const text = cell.document.getText();
         const lines = text.split("\n");
         const items: Array<{ type: string; level?: number; name: string; line: number }> = [];
@@ -635,19 +636,21 @@ Args:
   - response_format ('markdown' | 'json'): Output format`,
     SearchInputSchema.shape,
     async (params) => {
-      const editor = vscode.window.activeNotebookEditor;
-      if (!editor) {
-        return { content: [{ type: "text" as const, text: "Error: No active notebook." }], isError: true };
+      const parsed = SearchInputSchema.parse(params);
+      const accessCheck = await checkCanReadNotebook(parsed.notebook_uri);
+      if (!accessCheck.allowed) {
+        return { content: [{ type: "text" as const, text: `Error: ${accessCheck.error}` }], isError: true };
       }
 
-      const { query, case_sensitive, context_lines, response_format } = SearchInputSchema.parse(params);
+      const notebook = accessCheck.notebook!;
+      const { query, case_sensitive, context_lines, response_format } = parsed;
       const results: Array<{
         cellIndex: number;
         cellType: string;
         matches: Array<{ line: number; text: string; context?: string[] }>;
       }> = [];
 
-      for (const cell of editor.notebook.getCells()) {
+      for (const cell of notebook.getCells()) {
         const text = cell.document.getText();
         const lines = text.split("\n");
         const searchQuery = case_sensitive ? query : query.toLowerCase();
@@ -721,10 +724,13 @@ Args:
         return { content: [{ type: "text" as const, text: `Error: Cell index ${index} out of range.` }], isError: true };
       }
 
-      // Select the cell and clear its outputs (requires editor)
-      if (accessCheck.editor) {
-        accessCheck.editor.selection = new vscode.NotebookRange(index, index + 1);
+      // clearOutputs command operates on the active editor's selection — requires the target notebook to be the active editor
+      const activeEditor = vscode.window.activeNotebookEditor;
+      if (!accessCheck.editor || activeEditor?.notebook.uri.toString() !== accessCheck.notebook!.uri.toString()) {
+        return { content: [{ type: "text" as const, text: "Error: Cannot clear outputs — the target notebook must be the active tab. Switch to it and retry, or use notebook_uri to be explicit." }], isError: true };
       }
+
+      accessCheck.editor.selection = new vscode.NotebookRange(index, index + 1);
       await vscode.commands.executeCommand("notebook.cell.clearOutputs");
 
       if (response_format === ResponseFormat.JSON) {
@@ -744,6 +750,12 @@ Args:
       const accessCheck = await checkCanModifyNotebook(parsed.notebook_uri);
       if (!accessCheck.allowed) {
         return { content: [{ type: "text" as const, text: `Error: ${accessCheck.error}` }], isError: true };
+      }
+
+      // clearAllCellsOutputs command operates on the active editor — requires the target notebook to be the active editor
+      const activeEditorForClear = vscode.window.activeNotebookEditor;
+      if (!accessCheck.editor || activeEditorForClear?.notebook.uri.toString() !== accessCheck.notebook!.uri.toString()) {
+        return { content: [{ type: "text" as const, text: "Error: Cannot clear outputs — the target notebook must be the active tab. Switch to it and retry, or use notebook_uri to be explicit." }], isError: true };
       }
 
       await vscode.commands.executeCommand("notebook.clearAllCellsOutputs");

--- a/src/mcp/tools/kernel.ts
+++ b/src/mcp/tools/kernel.ts
@@ -6,6 +6,7 @@ import { parseOutputs, formatOutputsAsMarkdown } from "../../utils/output.js";
 import { checkCanReadNotebook } from "../../utils/notebook.js";
 
 const GetKernelInfoInputSchema = z.object({
+  notebook_uri: z.string().optional().describe("Optional notebook URI to target. If not provided, uses the active notebook."),
   response_format: ResponseFormatSchema
 }).strict();
 
@@ -131,21 +132,21 @@ Args:
   - response_format ('markdown' | 'json'): Output format (default: 'markdown')`,
     GetKernelInfoInputSchema.shape,
     async (params) => {
-      const editor = vscode.window.activeNotebookEditor;
-
-      if (!editor) {
+      const parsed = GetKernelInfoInputSchema.parse(params);
+      const accessCheck = await checkCanReadNotebook(parsed.notebook_uri);
+      if (!accessCheck.allowed) {
         return {
-          content: [{ type: "text" as const, text: "Error: No active notebook. Open a .ipynb file first." }],
+          content: [{ type: "text" as const, text: `Error: ${accessCheck.error}` }],
           isError: true
         };
       }
 
-      const parsed = GetKernelInfoInputSchema.parse(params);
+      const notebook = accessCheck.notebook!;
 
       let kernel: any;
       try {
         const jupyter = await getJupyterAPI();
-        kernel = await jupyter.kernels.getKernel(editor.notebook.uri);
+        kernel = await jupyter.kernels.getKernel(notebook.uri);
       } catch (error) {
         return {
           content: [{ type: "text" as const, text: `Error: Unable to access Jupyter extension. ${error instanceof Error ? error.message : String(error)}` }],
@@ -163,7 +164,7 @@ Args:
       const output = {
         language: kernel.language || "unknown",
         status: kernel.status || "unknown",
-        notebookUri: editor.notebook.uri.toString()
+        notebookUri: notebook.uri.toString()
       };
 
       if (parsed.response_format === ResponseFormat.JSON) {

--- a/src/utils/notebook.test.ts
+++ b/src/utils/notebook.test.ts
@@ -89,19 +89,22 @@ describe('checkCanModifyNotebook', () => {
   beforeEach(() => {
     // Reset mock state before each test
     (vscode.window as any).activeNotebookEditor = undefined;
+    (vscode.window as any).visibleNotebookEditors = [];
+    (vscode.workspace as any).notebookDocuments = [];
     (vscode.window as any).state = { focused: true };
   });
 
-  it('returns error when no active notebook editor', async () => {
+  it('returns error when no notebooks are open', async () => {
     (vscode.window as any).activeNotebookEditor = undefined;
+    (vscode.workspace as any).notebookDocuments = [];
 
     const result = await checkCanModifyNotebook();
 
     expect(result.allowed).toBe(false);
-    expect(result.error).toContain('No active notebook');
+    expect(result.error).toContain('No notebook open');
   });
 
-  it('returns error when window not focused', async () => {
+  it('allows modifications even when window not focused', async () => {
     const mockNotebook = { uri: { path: '/test.ipynb' } };
     const mockEditor = { notebook: mockNotebook };
     (vscode.window as any).activeNotebookEditor = mockEditor;
@@ -109,8 +112,9 @@ describe('checkCanModifyNotebook', () => {
 
     const result = await checkCanModifyNotebook();
 
-    expect(result.allowed).toBe(false);
-    expect(result.error).toContain('not focused');
+    // MCP-driven modifications should work regardless of window focus
+    expect(result.allowed).toBe(true);
+    expect(result.notebook).toBe(mockNotebook);
   });
 
   it('returns allowed with notebook when editor exists and window focused', async () => {
@@ -126,16 +130,40 @@ describe('checkCanModifyNotebook', () => {
     expect(result.editor).toBe(mockEditor);
   });
 
-  it('includes helpful error message with instructions', async () => {
-    const mockNotebook = { uri: { path: '/test.ipynb' } };
-    const mockEditor = { notebook: mockNotebook };
-    (vscode.window as any).activeNotebookEditor = mockEditor;
-    (vscode.window as any).state = { focused: false };
+  it('falls back to single open notebook when no active editor', async () => {
+    const mockNotebook = {
+      uri: { path: '/test.ipynb', toString: () => 'file:///test.ipynb' },
+      notebookType: 'jupyter-notebook'
+    };
+    (vscode.window as any).activeNotebookEditor = undefined;
+    (vscode.workspace as any).notebookDocuments = [mockNotebook];
+    (vscode.window as any).visibleNotebookEditors = [];
 
     const result = await checkCanModifyNotebook();
 
-    expect(result.error).toContain('Activate');
-    expect(result.error).toContain('another window');
+    expect(result.allowed).toBe(true);
+    expect(result.notebook).toBe(mockNotebook);
+  });
+
+  it('returns error listing notebooks when multiple are open and ambiguous', async () => {
+    const mockNotebook1 = {
+      uri: { path: '/test1.ipynb', toString: () => 'file:///test1.ipynb' },
+      notebookType: 'jupyter-notebook'
+    };
+    const mockNotebook2 = {
+      uri: { path: '/test2.ipynb', toString: () => 'file:///test2.ipynb' },
+      notebookType: 'jupyter-notebook'
+    };
+    (vscode.window as any).activeNotebookEditor = undefined;
+    (vscode.workspace as any).notebookDocuments = [mockNotebook1, mockNotebook2];
+    (vscode.window as any).visibleNotebookEditors = [];
+
+    const result = await checkCanModifyNotebook();
+
+    expect(result.allowed).toBe(false);
+    expect(result.error).toContain('Multiple notebooks');
+    expect(result.error).toContain('test1.ipynb');
+    expect(result.error).toContain('test2.ipynb');
   });
 });
 
@@ -143,19 +171,22 @@ describe('checkCanReadNotebook', () => {
   beforeEach(() => {
     // Reset mock state before each test
     (vscode.window as any).activeNotebookEditor = undefined;
+    (vscode.window as any).visibleNotebookEditors = [];
+    (vscode.workspace as any).notebookDocuments = [];
     (vscode.window as any).state = { focused: true };
   });
 
-  it('returns error when no active notebook editor', async () => {
+  it('returns error when no notebooks are open', async () => {
     (vscode.window as any).activeNotebookEditor = undefined;
+    (vscode.workspace as any).notebookDocuments = [];
 
     const result = await checkCanReadNotebook();
 
     expect(result.allowed).toBe(false);
-    expect(result.error).toContain('No active notebook');
+    expect(result.error).toContain('No notebook open');
   });
 
-  it('returns allowed even when window not focused (key difference from modify)', async () => {
+  it('returns allowed even when window not focused', async () => {
     const mockNotebook = { uri: { path: '/test.ipynb' } };
     const mockEditor = { notebook: mockNotebook };
     (vscode.window as any).activeNotebookEditor = mockEditor;
@@ -163,7 +194,6 @@ describe('checkCanReadNotebook', () => {
 
     const result = await checkCanReadNotebook();
 
-    // Read operations should work even when window is not focused
     expect(result.allowed).toBe(true);
     expect(result.notebook).toBe(mockNotebook);
   });
@@ -179,6 +209,20 @@ describe('checkCanReadNotebook', () => {
     expect(result.allowed).toBe(true);
     expect(result.notebook).toBe(mockNotebook);
     expect(result.editor).toBe(mockEditor);
+  });
+
+  it('falls back to single open notebook when no active editor', async () => {
+    const mockNotebook = {
+      uri: { path: '/test.ipynb', toString: () => 'file:///test.ipynb' },
+      notebookType: 'jupyter-notebook'
+    };
+    (vscode.window as any).activeNotebookEditor = undefined;
+    (vscode.workspace as any).notebookDocuments = [mockNotebook];
+
+    const result = await checkCanReadNotebook();
+
+    expect(result.allowed).toBe(true);
+    expect(result.notebook).toBe(mockNotebook);
   });
 });
 

--- a/src/utils/notebook.ts
+++ b/src/utils/notebook.ts
@@ -160,7 +160,7 @@ export function getNotebookEditor(notebook: vscode.NotebookDocument): vscode.Not
 
 /**
  * Resolve which notebook to use for an operation.
- * Priority: 1) Explicit URI parameter, 2) Active notebook editor
+ * Priority: 1) Explicit URI parameter, 2) Active notebook editor, 3) Single open notebook fallback
  *
  * This allows operations to continue even if user switches tabs,
  * as long as the notebook document is still open.
@@ -184,46 +184,71 @@ export async function resolveNotebook(notebookUri?: string): Promise<NotebookAcc
     };
   }
 
-  // Fall back to active notebook editor
+  // Try active notebook editor first
   const editor = vscode.window.activeNotebookEditor;
-  if (!editor) {
+  if (editor) {
+    return {
+      allowed: true,
+      notebook: editor.notebook,
+      editor
+    };
+  }
+
+  // Fallback: find notebook from open documents (handles tab-switch scenario)
+  const openNotebooks = vscode.workspace.notebookDocuments.filter(
+    doc => doc.notebookType === 'jupyter-notebook'
+  );
+
+  if (openNotebooks.length === 1) {
+    // Unambiguous — only one notebook open
+    const notebook = openNotebooks[0];
+    return {
+      allowed: true,
+      notebook,
+      editor: getNotebookEditor(notebook)
+    };
+  }
+
+  if (openNotebooks.length > 1) {
+    // Check if exactly one Jupyter notebook is visible (e.g., in a split view)
+    const openUris = new Set(openNotebooks.map(nb => nb.uri.toString()));
+    const visibleJupyterEditors = vscode.window.visibleNotebookEditors.filter(
+      editor => openUris.has(editor.notebook.uri.toString())
+    );
+    if (visibleJupyterEditors.length === 1) {
+      return {
+        allowed: true,
+        notebook: visibleJupyterEditors[0].notebook,
+        editor: visibleJupyterEditors[0]
+      };
+    }
+
+    // Multiple notebooks open, ambiguous — list them so the agent can retry with a URI
+    const listing = openNotebooks
+      .map(nb => `  - ${nb.uri.path.split("/").pop()}: ${nb.uri.toString()}`)
+      .join("\n");
     return {
       allowed: false,
-      error: "No active notebook. Open a .ipynb file first, or specify notebook_uri parameter."
+      error: `Multiple notebooks are open. Specify notebook_uri to target one:\n${listing}`
     };
   }
 
   return {
-    allowed: true,
-    notebook: editor.notebook,
-    editor
+    allowed: false,
+    error: "No notebook open. Open a .ipynb file first."
   };
 }
 
 /**
  * Check if notebook modifications are safe.
- * Returns error if:
- * - No active notebook (and no URI provided)
- * - Window is not focused (modifications would happen in background)
+ * Currently identical to checkCanReadNotebook — kept separate as a semantic
+ * marker so future versions can add additional guards for modifications
+ * (e.g., requiring a visible editor for certain operations).
  *
  * @param notebookUri Optional URI to target a specific notebook
  */
 export async function checkCanModifyNotebook(notebookUri?: string): Promise<NotebookAccessResult> {
-  const result = await resolveNotebook(notebookUri);
-  if (!result.allowed) {
-    return result;
-  }
-
-  // Check if this window is focused (only for implicit active notebook)
-  // If explicit URI was provided, we trust the caller knows what they're doing
-  if (!notebookUri && !vscode.window.state.focused) {
-    return {
-      allowed: false,
-      error: "Cannot modify notebook: This VS Code window is not focused.\n\nThe MCP server is running here but you appear to be working in another window.\n\nTo fix this:\n1. Switch to this VS Code window, OR\n2. Click '→ Activate' in the other window's status bar to move the server there"
-    };
-  }
-
-  return result;
+  return await resolveNotebook(notebookUri);
 }
 
 /**


### PR DESCRIPTION
## Summary

- All MCP tools now work when the notebook tab is not focused (e.g., user switches to a `.py` file, terminal, or another editor)
- Previously, 6 read-only tools (`list_cells`, `get_cell_content`, `get_cell_output`, `get_outline`, `search`, `get_kernel_info`) directly used `vscode.window.activeNotebookEditor`, which returns `undefined` when the notebook isn't the active tab — causing the MCP server to stop working during normal multitasking
- The `window.state.focused` check in `checkCanModifyNotebook()` also blocked all mutation operations when the VS Code window lost focus (e.g., clicking on the terminal)

## Changes

### Core: `src/utils/notebook.ts`
- **`resolveNotebook()`** — Added smart fallback chain when no `notebook_uri` is provided and no active editor:
  1. Single open Jupyter notebook → use it (unambiguous)
  2. Single visible Jupyter notebook editor → use it
  3. Multiple notebooks → error listing URIs so the agent can retry with a specific one
- **`checkCanModifyNotebook()`** — Removed `window.state.focused` check. MCP-driven operations (programmatic, not UI) should work regardless of window focus
- Filtered `notebookDocuments` to `jupyter-notebook` type to avoid false matches with VS Code interactive windows or other notebook providers

### Tools: `src/mcp/tools/cells.ts`
- **5 read-only tools** now use `checkCanReadNotebook()` instead of direct `activeNotebookEditor`: `notebook_list_cells`, `notebook_get_cell_content`, `notebook_get_cell_output`, `notebook_get_outline`, `notebook_search`
- **`notebook_list_cells`** gained `notebook_uri` parameter
- **`notebook_clear_outputs`** and **`notebook_clear_all_outputs`** now verify the target notebook is the active editor before running (these commands operate on the active editor's selection and could target the wrong notebook otherwise)

### Tools: `src/mcp/tools/kernel.ts`
- **`notebook_get_kernel_info`** — Added `notebook_uri` parameter, uses `checkCanReadNotebook()` instead of direct `activeNotebookEditor`

### Tests & Mocks
- Updated `src/__mocks__/vscode.ts` with `notebookDocuments` and `visibleNotebookEditors`
- Updated tests for new fallback behavior, removed focus-check tests, added single-notebook fallback and multi-notebook ambiguity tests

## Test plan

- [ ] `npm run build` — no compile errors
- [ ] `npm test` — all 43 tests pass
- [ ] Open a notebook in VS Code, switch to another tab, call `notebook_list_cells` via MCP — should return cells (previously returned "No active notebook" error)
- [ ] Open two notebooks, switch to a non-notebook tab, call without `notebook_uri` — should get helpful error listing both notebooks with their URIs
- [ ] Call `notebook_clear_outputs` when a different notebook is the active tab — should get clear error message instead of silently clearing the wrong notebook